### PR TITLE
Use npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ We would suggest forking this repository and go from there.
 Clone this repository, then:
 
 ```bash
-$ npm install -g gulp
 $ npm install
 ```
 
@@ -24,7 +23,7 @@ $ npm install
 Start the Tictail theme development environment:
 
 ```bash
-$ gulp
+$ npm run dev
 ```
 
 And then hit [http://localhost:5555/](http://localhost:5555/) to preview your theme.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "description": "An example theme using gulp-tictail",
   "license": "MIT",
   "repository": "https://github.com/tictail/theme-example.git",
-  "scripts": {},
+  "scripts": {
+    "dev": "gulp"
+  },
   "dependencies": {},
   "devDependencies": {
     "coffee-script": "^1.8.0",


### PR DESCRIPTION
Instead of requiring to install Gulp.js globally we can use NPM scripts. This will make the installation process much easier and faster.
